### PR TITLE
Small improvements to the openocd packaging

### DIFF
--- a/conda/openocd/build.sh
+++ b/conda/openocd/build.sh
@@ -3,6 +3,6 @@
 ./bootstrap
 ./configure --prefix="$PREFIX" \
     --enable-ftdi
-make
+make -j$CPU_COUNT
 make install
 

--- a/conda/openocd/build.sh
+++ b/conda/openocd/build.sh
@@ -9,3 +9,6 @@ cd build
 make -j$CPU_COUNT
 make install
 
+./src/openocd --version 2>&1 | head -1 | sed -e's/-/_/g' -e's/.* 0\./0./' -e's/ .*//' > ../__conda_version__.txt
+./src/openocd --version 2>&1 | head -1 | sed -e's/[^(]*(//' -e's/)//' -e's/://g' -e's/-/_/g' > ../__conda_buildstr__.txt
+TZ=UTC date +%Y%m%d%H%M%S > ../__conda_buildnum__.txt

--- a/conda/openocd/build.sh
+++ b/conda/openocd/build.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
 ./bootstrap
-./configure --prefix="$PREFIX" \
-    --enable-ftdi
+mkdir build
+cd build
+../configure \
+  --prefix="$PREFIX" \
+  --enable-ftdi
 make -j$CPU_COUNT
 make install
 

--- a/conda/openocd/meta.yaml
+++ b/conda/openocd/meta.yaml
@@ -9,6 +9,12 @@ source:
 build:
   number: 0
 
+test:
+  commands:
+    - openocd -v
+    - openocd -v 2>&1 | head -1 | grep -q -v dirty
+    - openocd -v 2>&1 | head -1 | grep -q -- "-[0-9][0-9][0-9][0-9][0-9]-[0-9a-z]\+ "
+
 requirements:
   build:
     - system # [linux]

--- a/conda/openocd/meta.yaml
+++ b/conda/openocd/meta.yaml
@@ -12,8 +12,8 @@ build:
 test:
   commands:
     - openocd -v
-    - openocd -v 2>&1 | head -1 | grep -q -v dirty
-    - openocd -v 2>&1 | head -1 | grep -q -- "-[0-9][0-9][0-9][0-9][0-9]-[0-9a-z]\+ "
+    - openocd -v 2>&1 | head -1 | grep -q -v dirty # [linux]
+    - openocd -v 2>&1 | head -1 | grep -q -- "-[0-9][0-9][0-9][0-9][0-9]-[0-9a-z]\+ " # [linux]
 
 requirements:
   build:


### PR DESCRIPTION
The major improvement is to generate proper versioning information in the conda package.
The same generation probably needs to be added to bld.bat too, but I don't have a way to test on Windows at the moment.

This comes from our openocd conda package at https://github.com/timvideos/conda-hdmi2usb-packages/tree/master/openocd
You can see the output at https://anaconda.org/TimVideos/openocd/files
