### PR TITLE
pyqtgraph: use anaconda default pyqt (fixes artiq/#670)

### DIFF
--- a/conda/quamash/meta.yaml
+++ b/conda/quamash/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - pyqt5
   run:
     - python
-    - pyqt5
+    - pyqt
 
 test:
   imports:


### PR DESCRIPTION
see https://github.com/m-labs/artiq/pull/677